### PR TITLE
Inserir BH/MG

### DIFF
--- a/front-end/dados/cidades.json
+++ b/front-end/dados/cidades.json
@@ -1,4 +1,5 @@
 {
+  "Belo Horizonte": "Belo Horizonte, MG",
   "Rio de Janeiro": "Rio de Janeiro, RJ",
   "São Paulo": "São Paulo, SP"
 }


### PR DESCRIPTION
Inseri BH ( ordem alfabética )

Considere atualizar a interface para facilitar a localização da cidade, caso tenham várias cidades.
